### PR TITLE
Docs: Added new config variable to config example in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This is the contents of the published config file:
 ```php
 return [
 
+    'enabled' => env('BLADE_CACHE_DIRECTIVE_ENABLED', true),
+
     'ttl' => env('BLADE_CACHE_DIRECTIVE_TTL', 3600),
 
 ];


### PR DESCRIPTION
Hello!

Just a small edit based on the changes in https://github.com/ryangjchandler/blade-cache-directive/pull/10: you added the contents of the published config file to the readme in the past but forgot to update it with the latest change:

> This is the contents of the published config file:
>
> ```php
> return [
> 
>     'ttl' => env('BLADE_CACHE_DIRECTIVE_TTL', 3600),
>
> ];
>```

Should be:

```php
return [

    'enabled' => env('BLADE_CACHE_DIRECTIVE_ENABLED', true),

    'ttl' => env('BLADE_CACHE_DIRECTIVE_TTL', 3600),

];
```

